### PR TITLE
Fix two HTML errors

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -115,13 +115,13 @@ a:hover {
   text-decoration: underline;
 }
 
-#information {
+.information {
   display: block;
   font-size: 12px;
   color: #7D7D7D;
 }
 
-#information a {
+.information a {
   color: #7D7D7D;
 }
 

--- a/index.html
+++ b/index.html
@@ -103,13 +103,13 @@
     <ul id="buttons">
       <li>
         <a class="link" href="https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.0.3.1/OpenRCT2-0.0.3.1-windows.zip">Download Stable</a>
-        <div id="information">
+        <div class="information">
           <span class="version">0.0.3.1</span> — <a class="platform" href="#" title="Change platform…">Windows</a> — <span class="size">12.3 MB</span>
         </div>
       </li>
       <li>
         <a href="https://openrct2.org/downloads/latest/develop">Download Development Build</a>
-        <div id="information">Windows, Linux &amp; OS X</div>
+        <div class="information">Windows, Linux &amp; OS X</div>
       </li>
     </ul>
   </div>

--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
       <li>
         <a class="link" href="https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.0.3.1/OpenRCT2-0.0.3.1-windows.zip">Download Stable</a>
         <div id="information">
-          <span class="version">0.0.3.1</span> — <a class="platform" href="#" alt="Change platform…">Windows</a> — <span class="size">12.3 MB</span>
+          <span class="version">0.0.3.1</span> — <a class="platform" href="#" title="Change platform…">Windows</a> — <span class="size">12.3 MB</span>
         </div>
       </li>
       <li>


### PR DESCRIPTION
This fixes two HTML errors found at https://validator.w3.org/nu/?doc=https%3A%2F%2Fopenrct2.website. The `alt` property is not valid for anchor elements and the `title` property should be used instead. There were two elements with the `information` ID as well, so I replaced those with a class.

Seems like missing newlines snuck in as well...
