### PR TITLE
fix broken version links

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,19 +19,19 @@
     var platforms = {
       windows: {
         name: 'Windows',
-        link: 'https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.0.6/OpenRCT2-v0.0.6.0-windows-portable-x64.zip',
+        link: 'https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.0.6/OpenRCT2-0.0.6.0-windows-portable-x64.zip',
         size: 6462629, //bytes
         version: '0.0.6'
       },
       linux: {
         name: 'Linux',
-        link: 'https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.0.6/OpenRCT2-v0.0.6.0-linux-x86_64.tar.gz',
+        link: 'https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.0.6/OpenRCT2-0.0.6.0-linux-x86_64.tar.gz',
         size: 14009751, //bytes
         version: '0.0.6'
       },
       osx: {
         name: 'OS X',
-        link: 'https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.0.6/OpenRCT2-v0.0.6.0-macos.zip',
+        link: 'https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.0.6/OpenRCT2-0.0.6.0-macos.zip',
         size: 7266860,
         version: '0.0.6'
       }


### PR DESCRIPTION
The `v` in the semver was dropped. This is to fix the broken links that contain the version string.