### PR TITLE
Finish Getting Started, improve JS

### DIFF
--- a/assets/css/getting-started.css
+++ b/assets/css/getting-started.css
@@ -6,7 +6,13 @@ body {
     color: #fff;
     background: url(../img/screenshot.png) no-repeat #000;
     background-position-x: center;
+    background-attachment: fixed;
     -webkit-text-size-adjust: 100%; /* fix footer bug on iOS */
+}
+
+body img {
+    display: block;
+    margin: 0 auto;
 }
 
 #gradient {
@@ -35,7 +41,7 @@ body {
     text-align: center;
 }
 
-.btn-platforms, .btn-distros {
+.btn-platforms, .btn-distros, .btn-phases, .btn-extractplatforms {
     text-align: center;
 }
 
@@ -72,7 +78,7 @@ body {
     width: 800px;
 }
 
-.terminal {
+div.terminal {
     background-color: #000;
     border-radius: 6px;
     color: #eee;
@@ -80,6 +86,16 @@ body {
     line-height: 20px;
     margin: 8px 0;
     padding: 8px 10px;
+    white-space: pre-line;
+}
+
+span.terminal {
+    background-color: #000;
+    border-radius: 6px;
+    color: #eee;
+    font-family: Consolas, monospace;
+    line-height: 20px;
+    padding: 0 8px 0 8px;
     white-space: pre-line;
 }
 
@@ -94,11 +110,11 @@ a:hover {
 
 h2 {
     font-family: 'Segoe UI Light', Arial, sans-serif;
-    margin: 4px 0;
+    margin: 4px 0 12px 0;
     text-align: center;
 }
 
-.page-platform, .page-distro {
+.page-platform, .page-distro, .page-phase, .page-extractplatform {
     display: none;
 }
 

--- a/assets/js/getting-started.js
+++ b/assets/js/getting-started.js
@@ -1,0 +1,60 @@
+function setupPageControl(container, pageType) {
+    var buttons = document.querySelectorAll(container + ' .btn-' + pageType);
+    for (var i = 0; i < buttons.length; i++) {
+        buttons[i].addEventListener('click', function () {
+            if (!this.classList.contains('active')) {
+                var activeButtons = document.querySelectorAll(container + ' .btn-' + pageType + '.active');
+                for (var j = 0; j < activeButtons.length; j++) {
+                    activeButtons[j].classList.remove('active');
+                }
+                this.classList.add('active');
+
+                var pages = document.querySelectorAll(container + ' .page-' + pageType);
+                for (var j = 0; j < pages.length; j++) {
+                    pages[j].classList.remove('show');
+                }
+                var targetPage = document.getElementById(this.getAttribute('data-page'));
+                if (targetPage) {
+                    targetPage.classList.add('show');
+                }
+            }
+        });
+    }
+}
+
+function showContent(slug) {
+    document.querySelector('[data-page="content-'+slug+'"]').click();
+}
+
+setupPageControl('body', 'platform');
+setupPageControl('body', 'extractplatform');
+setupPageControl('body', 'phase');
+
+var platformPages = document.querySelectorAll('.page-platform');
+for (var i = 0; i < platformPages.length; i++) {
+    var container = '#' + platformPages[i].id;
+    setupPageControl(container, 'distro');
+}
+
+switch(openrct2.currentPlatform) {
+    case openrct2.Platform.WINDOWS32:
+        showContent('windows-x86');
+        showContent('windows');
+        showContent('extractwindows');
+        break;
+    case openrct2.Platform.WINDOWS64:
+        showContent('windows-x64');
+        showContent('windows');
+        showContent('extractwindows');
+        break;
+    case openrct2.Platform.MACOS:
+        showContent('macos');
+        showContent('extractlinuxmacos');
+        break;
+    case openrct2.Platform.LINUX:
+        showContent('linux');
+        showContent('extractlinuxmacos');
+        break;
+    default:
+        break;
+}

--- a/assets/js/home.js
+++ b/assets/js/home.js
@@ -1,0 +1,45 @@
+// http://stackoverflow.com/questions/15900485/correct-way-to-convert-size-in-bytes-to-kb-mb-gb-in-javascript
+function formatBytes (bytes, decimals) {
+   if(bytes == 0) return '0 Byte';
+   var k = 1000;
+   var dm = decimals + 1 || 3;
+   var sizes = ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+   var i = Math.floor(Math.log(bytes) / Math.log(k));
+   return (bytes / Math.pow(k, i)).toPrecision(dm) + ' ' + sizes[i];
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+  var link = document.getElementsByClassName('link')[0];
+  var size = document.getElementsByClassName('size')[0];
+  var version = document.getElementsByClassName('version')[0];
+  var platform = document.getElementsByClassName('platform')[0];
+
+  if (openrct2.currentPlatform !== openrct2.Platform.UNKNOWN) {
+    link.href = openrct2.currentPlatform.link;
+    size.innerHTML = formatBytes(openrct2.currentPlatform.size, 1);
+    platform.innerHTML = openrct2.currentPlatform.name;
+    version.innerHTML = openrct2.currentPlatform.version;
+  }
+
+  platform.addEventListener('click', function (e) {
+    e.preventDefault();
+    
+    var keys = Object.keys(openrct2.Platform);
+
+    for (var i = 0; i <= keys.length; i++) {
+      if (openrct2.Platform[keys[i]].name === platform.innerHTML) {
+        if (i + 1 >= keys.length) {
+          i = 1;
+        } else {
+          i = i + 1;
+        }
+        
+        link.href = openrct2.Platform[keys[i]].link;
+        size.innerHTML = formatBytes(openrct2.Platform[keys[i]].size, 1);
+        platform.innerHTML = openrct2.Platform[keys[i]].name;
+        version.innerHTML = openrct2.Platform[keys[i]].version;
+        break;
+      }
+    }
+  });
+});

--- a/assets/js/openrct2.website.js
+++ b/assets/js/openrct2.website.js
@@ -1,0 +1,47 @@
+var openrct2 = {};
+
+openrct2.Platform = Object.freeze({
+    UNKNOWN: {},
+    WINDOWS32: {
+        name: 'Windows (32-bit)',
+        link: 'https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.0.6/OpenRCT2-0.0.6.0-windows-portable-x64.zip',
+        size: 6462629, //bytes
+        version: '0.0.6'
+    },
+    WINDOWS64: {
+        name: 'Windows (64-bit)',
+        link: 'https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.0.6/OpenRCT2-0.0.6.0-windows-portable-x64.zip',
+        size: 6462629, //bytes
+        version: '0.0.6'
+    },
+    MACOS: {
+        name: 'macOS',
+        link: 'https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.0.6/OpenRCT2-0.0.6.0-macos.zip',
+        size: 7266860,
+        version: '0.0.6'
+    },
+    LINUX: {
+        name: 'Linux',
+        link: 'https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.0.6/OpenRCT2-0.0.6.0-linux-x86_64.tar.gz',
+        size: 14009751, //bytes
+        version: '0.0.6'
+    }
+});  // Object.freeze() prevents this from being futzed with
+
+function getPlatform(){
+    if (navigator.platform.indexOf('Win') >= 0){
+        if (navigator.userAgent.indexOf("WOW64") === -1 && navigator.userAgent.indexOf("Win64") === -1 ){
+            return openrct2.Platform.WINDOWS32;
+        } else {
+            return openrct2.Platform.WINDOWS64;  // 64-bit is the default as it is by far the most common these days
+        }
+    } else if (navigator.platform.indexOf('Linux') >= 0){
+        return openrct2.Platform.LINUX;
+    } else if (navigator.platform === 'MacIntel'){
+        return openrct2.Platform.MACOS;
+    } else {
+        return openrct2.Platform.UNKNOWN;
+    }
+}
+
+openrct2.currentPlatform = getPlatform();

--- a/getting-started/index.html
+++ b/getting-started/index.html
@@ -155,8 +155,10 @@
                                     <div class="step"><span>1</span></div>
                                     <div class="step-body">
                                         <h3>Install OpenRCT2</h3>
-                                        <div>You can obtain the latest release or develop version of OpenRCT2 from the <a href="https://aur.archlinux.org">AUR</a>.</div>
+                                        <div>If you want the release build - stable, well-tested, but might have fewer features than the latest development build, install the standard package:</div>
                                         <div class="terminal">yaourt -S openrct2</div>
+										<div>Alternatively, if you want the latest development build, install the -git package from the <a href="https://aur.archlinux.org">AUR</a>. The dev builds are analogous to beta versions - they should work, but don't expect everything to be perfect.</div>
+                                        <div class="terminal">yaourt -S openrct2-git</div>
                                     </div>
                                 </li>
                                 <li>
@@ -195,7 +197,7 @@
                                     </div>
                                 <li>
                                 <li>
-                                    <div class="step"><span>2</span></div>
+                                    <div class="step"><span>4</span></div>
                                     <div class="step-body">
                                         <h3>Find your RCT2 installation</h3>
                                         <p>When OpenRCT2 first launches, you will be prompted to select the directory where you installed RCT2. You can also set the RCT2 path from the command line should you wish - use the command below.</p>
@@ -230,7 +232,7 @@
                                     </div>
                                 <li>
                                 <li>
-                                    <div class="step"><span>2</span></div>
+                                    <div class="step"><span>4</span></div>
                                     <div class="step-body">
                                         <h3>Find your RCT2 installation</h3>
                                         <p>When OpenRCT2 first launches, you will be prompted to select the directory where you installed RCT2. You can also set the RCT2 path from the command line should you wish - use the command below.</p>
@@ -270,7 +272,7 @@
                                     </div>
                                 <li>
                                 <li>
-                                    <div class="step"><span>2</span></div>
+                                    <div class="step"><span>4</span></div>
                                     <div class="step-body">
                                         <h3>Find your RCT2 installation</h3>
                                         <p>When OpenRCT2 first launches, you will be prompted to select the directory where you installed RCT2. You can also set the RCT2 path from the command line should you wish - use the command below.</p>

--- a/getting-started/index.html
+++ b/getting-started/index.html
@@ -9,310 +9,367 @@
         <div>
             <div id="banner">
                 <h1>Getting Started</h1>
-                <div class="btn-platforms">
-                    <div class="btn-h-container">
-                        <button class="btn-platform active" data-page="content-windows">Windows</button>
-                        <button class="btn-platform" data-page="content-linux">Linux</button>
-                        <button class="btn-platform" data-page="content-macos">macOS</button>
-                    </div>
+                <div class="btn-phases">
+                        <div class="btn-h-container">
+                            <button class="btn-phase active" data-page="content-phase-one">1 | Get RCT2</button>
+                            <button class="btn-phase" data-page="content-phase-two">2 | Extract RCT2 files</button>
+                            <button class="btn-phase" data-page="content-phase-three">3 | Install OpenRCT2</button>
+                            <button class="btn-phase" data-page="content-phase-four">4 | Tips &amp; tricks</button>
+                        </div>
                 </div>
             </div>
             <div id="content">
-                <div id="content-windows" class="page-platform show">
-                    <div class="btn-h-container-center btn-distros">
-                        <div>Select your environment</div>
+                <div id="content-phase-one" class="page-phase show">
+                <h2>Get RCT2</h2>
+                    <p>OpenRCT2 needs the object files (containing graphics, sounds and models) from the original RollerCoaster Tycoon 2 to work. You'll need to have a copy of RCT2 before beginning.</p>
+                    <h3>Where can I get it?</h3>
+                    <p>If you have an old CD copy sitting around, you're good - move on to step two.</p>
+                    <p>Otherwise, you can buy the game at <a href="https://www.gog.com/game/rollercoaster_tycoon_2">GOG.com</a> or <a href="http://store.steampowered.com/app/285330/RollerCoaster_Tycoon_2_Triple_Thrill_Pack/">through Steam</a>. The GOG version is <strong>strongly</strong> recommended for those on Linux or macOS for ease of installation. Both of the packs linked also contain the two expansion packs, Wacky Worlds and Time Twister.</p>
+                    <p>OpenRCT2 can also import scenarios and some graphics from the original RollerCoaster Tycoon (RCT1) - if this is something you'd like to do, get your RCT1 CD ready or purchase a copy (you can also get RCT1 through <a href="https://www.gog.com/game/rollercoaster_tycoon_deluxe">GOG</a> or <a href="http://store.steampowered.com/app/285310/RollerCoaster_Tycoon_Deluxe/">Steam</a>).</p>
+                </div>
+                <div id="content-phase-two" class="page-phase">
+                <h2>Extract RCT2 files</h2>
+                    <div class="btn-extractplatforms">
+                        <div>Select your operating system</div>
                         <div class="btn-h-container">
-                            <button class="btn-distro" data-page="content-windows-x32">32-bit</button>
-                            <button class="btn-distro active" data-page="content-windows-x64">64-bit</button>
+                            <button class="btn-extractplatform active" data-page="content-extractwindows">Windows</button>
+                            <button class="btn-extractplatform" data-page="content-extractlinuxmacos">Linux &amp; macOS</button>
                         </div>
                     </div>
-                    <div id="content-windows-x32" class="page-distro">
-                        <h2>Install OpenRCT2 for Windows (32 bit)</h2>
+                    <div id="content-extractwindows" class="page-extractplatform show">
+                        <p>If you're on Windows, all you need to do is run the installer (whether from GOG, Steam, or your CD). Install RCT2 as normal, then go on to the next step.</p>
+                    </div>
+                    <div id="content-extractlinuxmacos" class="page-extractplatform">
+                        <h3>Option 1: WINE</h3>
+                        <h4>GOG.com & Retail</h4>
+                        <p>You can use WINE - a reimplementation of the Windows API - to run the installer. Using a wrapper such as <a href="https://www.playonlinux.com">PlayOnLinux</a> or <a href="https://www.playonmac.com">PlayOnMac</a> is recommended to make the process easier. Follow the wizard the wrapper provides, pointing it to the installer at the appropriate point. It does not matter if RCT2 actually runs, as we'll be using the OpenRCT2 application.</p>
+                        <h4>Steam</h4>
+                        Follow a guide for installing Steam via WINE, such as <a href="https://wiki.archlinux.org/index.php/Steam/Wine">this excellent one</a> from the Arch Wiki. Download and install RCT2, remembering to note/copy the path where you installed it.
+                        <h3>Option 2: Manual extraction</h3>
+                        <h4>GOG.com</h4>
+                        <p>If you have the GOG.com installer, you can extract it using <a href="http://constexpr.org/innoextract/">innoextract</a>. Check if your distribution has a package for it, if not it can be downloaded from the link provided.</p>
+                        <p>Create a folder for the RCT2 files, and move the installer package to it, as innoextract will simply dump the contents to the folder where the installer resides. Open a terminal window, navigate to the folder you created and run the following command:</p>
+                        <div class="terminal">innoextract INSTALLERNAME.exe</div>
+                        <p>The files will be extracted, and you're ready to go.</p>
+                        <h4>Retail</h4>
+                        <p>If you have the retail installer, you'll need <a href="https://github.com/twogood/unshield">unshield</a> to extract it. There may be a package available for your distribution, or build from source (grab the source from the link, then run <span class="terminal">cmake . &amp;&amp; make</span>).</p>
+                        <p>Once you have unshield, run the following commands, replacing <strong>PATH-TO-EXTRACT-FILES-TO</strong> and <strong>INSTALLER-LOCATION</strong> appropriately:</p>
+                        <div class="terminal">unshield -g Minimum -d "PATH-TO-EXTRACT-FILES-TO" x "INSTALLER-LOCATION/data1.hdr"<br />cp -R "$INSTALLDIR/Data/" "$EXTRACTDIR/Minimum/Data"<br />mv "$EXTRACTDIR/Minimum" "$EXTRACTDIR/RCT2"</div>
+                        <h4>Steam</h4>
+                        <p>Launch Steam with the console enabled.</p>
+                        <p><strong>Linux:</strong></p>
+                        <div class="terminal">steam -console</div>
+                        <p><strong>macOS:</strong></p>
+                        <div class="terminal">/Applications/Steam.app/Contents/MacOS/steam_osx -console</div>
+                        <p>You should now see additional tab in the top menu called CONSOLE. Open it, and enter the following command.
+                        <div class="terminal">download_depot 285330 285331</div>
+                        <p>Once the download is complete, the console will display something along the lines of</p>
+                        <div class="terminal">Depot download complete : /home/&lt;username>/.local/share/Steam/ubuntu12_32\steamapps\content\app_285330\depot_285331</div>
+                        <p>The game won't show up in the 'installed' list - this is normal.</p>
+                    </div>
+                </div>
+                <div id="content-phase-three" class="page-phase">
+                    <div class="btn-platforms">
+                        <div>Select your operating system</div>
+                        <div class="btn-h-container">
+                            <button class="btn-platform active" data-page="content-windows">Windows</button>
+                            <button class="btn-platform" data-page="content-linux">Linux</button>
+                            <button class="btn-platform" data-page="content-macos">macOS</button>
+                        </div>
+                    </div>
+                    <div id="content-windows" class="page-platform show">
+                        <div class="btn-h-container-center btn-distros">
+                            <div>Select your environment</div>
+                            <div class="btn-h-container">
+                                <button class="btn-distro" data-page="content-windows-x86">32-bit</button>
+                                <button class="btn-distro active" data-page="content-windows-x64">64-bit</button>
+                            </div>
+                        </div>
+                        <div id="content-windows-x86" class="page-distro">
+                            <h2>Install OpenRCT2 for Windows (32-bit)</h2>
+                            <ol class="steps">
+                                <li>
+                                    <div class="step"><span>1</span></div>
+                                    <div class="step-body">
+                                        <h3>Install OpenRCT2</h3>
+                                        <p>Use the links below to download OpenRCT2. The latest release is a stable, well-tested build, but may have fewer features than the latest development builds. The dev builds are analogous to beta versions - they should work, but don't expect everything to be perfect.</p>
+                                        <p>Note: If you wish to play online, it is recommended to use the latest development build, as most servers will be running this; you cannot connect to a server running a different version.</p>
+                                        <div><a class="btn-download" href="http://cdn.limetric.com/games/openrct2/0.0.7/master/36f1210/2/OpenRCT2-0.0.7-windows-win32.exe">Download latest release</a></div>
+                                        <div><a class="btn-download" href="https://openrct2.org/downloads/latest/develop">Download latest development build</a></div>
+                                    </div>
+                                </li>
+                                <li>
+                                    <div class="step"><span>2</span></div>
+                                    <div class="step-body">
+                                        <h3>Find your RCT2 installation</h3>
+                                        <p>When you launch OpenRCT2 for the first time, OpenRCT2 will try to find your RCT2 installation. It will check the default locations
+                                            that RCT2 is typically installed for all known releases. If it is unable to find it, or you have installed it to a different location,
+                                            OpenRCT2 will show a dialog allowing you to select the directory containing your RCT2 files.
+                                        </p>
+                                    </div>
+                                </li>
+                            </ol>
+                        </div>
+                        <div id="content-windows-x64" class="page-distro show">
+                            <h2>Install OpenRCT2 for Windows (64-bit)</h2>
+                            <ol class="steps">
+                                <li>
+                                    <div class="step"><span>1</span></div>
+                                    <div class="step-body">
+                                        <h3>Install OpenRCT2</h3>
+                                        <p>Use the links below to download OpenRCT2. The latest release is a stable, well-tested build, but may have fewer features than the latest development builds. The dev builds are analogous to beta versions - they should work, but don't expect everything to be perfect.</p>
+                                        <p>Note: If you wish to play online, it is recommended to use the latest development build, as most servers will be running this; you cannot connect to a server running a different version.</p>
+                                        <div><a class="btn-download" href="http://cdn.limetric.com/games/openrct2/0.0.7/master/36f1210/7/OpenRCT2-0.0.7-windows-x64.exe">Download latest release</a></div>
+                                        <div><a class="btn-download" href="https://openrct2.org/downloads/latest/develop">Download latest development build</a></div>
+                                    </div>
+                                </li>
+                                <li>
+                                    <div class="step"><span>2</span></div>
+                                    <div class="step-body">
+                                        <h3>Find your RCT2 installation</h3>
+                                        <p>When you launch OpenRCT2 for the first time, OpenRCT2 will try to find your RCT2 installation. It will check the default locations
+                                            that RCT2 is typically installed for all known releases. If it is unable to find it, or you have installed it to a different location,
+                                            OpenRCT2 will show a dialog allowing you to select the directory containing your RCT2 files.
+                                        </p>
+                                    </div>
+                                </li>
+                            </ol>
+                        </div>
+                    </div>
+                    <div id="content-linux" class="page-platform">
+                        <div class="btn-h-container-center btn-distros">
+                            <div>Select your Linux distro</div>
+                            <div class="btn-h-container">
+                                <button class="btn-distro active" data-page="content-linux-arch">Arch Linux</button>
+                                <button class="btn-distro" data-page="content-linux-opensuse">openSUSE</button>
+                                <button class="btn-distro" data-page="content-linux-ubuntu">Debian, Ubuntu, Mint</button>
+                                <button class="btn-distro" data-page="content-linux-alpine">Alpine</button>
+                                <button class="btn-distro" data-page="content-linux-gentoo">Gentoo</button>
+                                <button class="btn-distro" data-page="content-linux-fedora">Fedora</button>
+                            </div>
+                        </div>
+                        <div id="content-linux-arch" class="page-distro show">
+                            <h2>Install OpenRCT2 for Arch Linux</h2>
+                            <ol class="steps">
+                                <li>
+                                    <div class="step"><span>1</span></div>
+                                    <div class="step-body">
+                                        <h3>Install OpenRCT2</h3>
+                                        <div>You can obtain the latest release or develop version of OpenRCT2 from the <a href="https://aur.archlinux.org">AUR</a>.</div>
+                                        <div class="terminal">yaourt -S openrct2</div>
+                                    </div>
+                                </li>
+                                <li>
+                                    <div class="step"><span>2</span></div>
+                                    <div class="step-body">
+                                        <h3>Find your RCT2 installation</h3>
+                                        <p>When OpenRCT2 first launches, you will be prompted to select the directory where you installed RCT2. You can also set the RCT2 path from the command line should you wish - use the command below.</p>
+                                        <div class="terminal">openrct2 set-rct2 /path/to/rct2-install</div>
+                                    </div>
+                                </li>
+                            </ol>
+                        </div>
+                        <div id="content-linux-alpine" class="page-distro">
+                            <h2>Install OpenRCT2 for Alpine Linux</h2>
+                            <ol class="steps">
+                                <li>
+                                    <div class="step"><span>1</span></div>
+                                    <div class="step-body">
+                                        <h3>Install dependencies</h3>
+                                        <div>You will need the dependencies to build the game - there is no package in apk for the game as of yet.</div>
+                                        <div class="terminal">apk add git gcc g++ jansson-dev libzip-dev curl-dev libressl-dev sdl2-dev fontconfig-dev sdl2_ttf-dev fts-dev</div>
+                                    </div>
+                                </li>
+                                <li>
+                                    <div class="step"><span>2</span></div>
+                                    <div class="step-body">
+                                        <h3>Build the game</h3>
+                                        <div class="terminal">git clone https://github.com/OpenRCT2/OpenRCT2.git &amp;&amp; cd ./OpenRCT2 &amp;&amp; mkdir build &amp;&amp; cd build &amp;&amp; cmake ../ &amp;&amp; make</div>
+                                    </div>
+                                </li>
+                                <li>
+                                    <div class="step"><span>3</span></div>
+                                    <div class="step-body">
+                                        <h3>Set up the files</h3>
+                                        <div class="terminal">cp -r ../data/ ./data/ &amp;&amp; make g2 &amp;&amp; mv ./g2.dat ./data/g2.dat</div>
+                                    </div>
+                                <li>
+                                <li>
+                                    <div class="step"><span>2</span></div>
+                                    <div class="step-body">
+                                        <h3>Find your RCT2 installation</h3>
+                                        <p>When OpenRCT2 first launches, you will be prompted to select the directory where you installed RCT2. You can also set the RCT2 path from the command line should you wish - use the command below.</p>
+                                        <div class="terminal">openrct2 set-rct2 /path/to/rct2-install</div>
+                                    </div>
+                                </li>
+                            </ol>
+                        </div>
+                        <div id="content-linux-gentoo" class="page-distro">
+                            <h2>Install OpenRCT2 for Gentoo</h2>
+                            <ol class="steps">
+                                <li>
+                                    <div class="step"><span>1</span></div>
+                                    <div class="step-body">
+                                        <h3>Install dependencies</h3>
+                                        <div>You will need the dependencies to build the game - there is no package for the game as of yet.</div>
+                                        <div class="terminal">sudo emerge --ask --verbose git gcc g++ jansson-dev libzip-dev curl-dev libressl-dev sdl2-dev fontconfig-dev sdl2_ttf-dev fts-dev</div>
+                                    </div>
+                                </li>
+                                <li>
+                                    <div class="step"><span>2</span></div>
+                                    <div class="step-body">
+                                        <h3>Build the game</h3>
+                                        <div class="terminal">git clone https://github.com/OpenRCT2/OpenRCT2.git &amp;&amp; cd ./OpenRCT2 &amp;&amp; mkdir build &amp;&amp; cd build &amp;&amp; cmake ../ &amp;&amp; make</div>
+                                    </div>
+                                </li>
+                                <li>
+                                    <div class="step"><span>3</span></div>
+                                    <div class="step-body">
+                                        <h3>Set up the files</h3>
+                                        <div class="terminal">cp -r ../data/ ./data/ &amp;&amp; make g2 &amp;&amp; mv ./g2.dat ./data/g2.dat</div>
+                                    </div>
+                                <li>
+                                <li>
+                                    <div class="step"><span>2</span></div>
+                                    <div class="step-body">
+                                        <h3>Find your RCT2 installation</h3>
+                                        <p>When OpenRCT2 first launches, you will be prompted to select the directory where you installed RCT2. You can also set the RCT2 path from the command line should you wish - use the command below.</p>
+                                        <div class="terminal">openrct2 set-rct2 /path/to/rct2-install</div>
+                                    </div>
+                                </li>
+                            </ol>
+                        </div>
+                        <div id="content-linux-fedora" class="page-distro">
+                            <h2>Install OpenRCT2 for Fedora</h2>
+                            <ol class="steps">
+                                <li>
+                                    <div class="step"><span>1</span></div>
+                                    <div class="step-body">
+                                        <h3>Install dependencies</h3>
+                                        <div>You will need the dependencies to build the game - there is no package for the game as of yet.</div>
+                                        <div class="terminal">sudo dnf install gcc gcc-c++ jansson-devel \
+                                            SDL2_ttf-devel openssl-devel \
+                                            speexdsp-devel libcurl-devel \
+                                            cmake fontconfig-devel freetype-devel \
+                                            libpng-devel libzip-devel mesa-libGL-devel
+                                        </div>
+                                    </div>
+                                </li>
+                                <li>
+                                    <div class="step"><span>2</span></div>
+                                    <div class="step-body">
+                                        <h3>Build the game</h3>
+                                        <div class="terminal">git clone https://github.com/OpenRCT2/OpenRCT2.git &amp;&amp; cd ./OpenRCT2 &amp;&amp; mkdir build &amp;&amp; cd build &amp;&amp; cmake ../ &amp;&amp; make</div>
+                                    </div>
+                                </li>
+                                <li>
+                                    <div class="step"><span>3</span></div>
+                                    <div class="step-body">
+                                        <h3>Set up the files</h3>
+                                        <div class="terminal">cp -r ../data/ ./data/ &amp;&amp; make g2 &amp;&amp; mv ./g2.dat ./data/g2.dat</div>
+                                    </div>
+                                <li>
+                                <li>
+                                    <div class="step"><span>2</span></div>
+                                    <div class="step-body">
+                                        <h3>Find your RCT2 installation</h3>
+                                        <p>When OpenRCT2 first launches, you will be prompted to select the directory where you installed RCT2. You can also set the RCT2 path from the command line should you wish - use the command below.</p>
+                                        <div class="terminal">openrct2 set-rct2 /path/to/rct2-install</div>
+                                    </div>
+                                </li>
+                            </ol>
+                        </div>
+                        <div id="content-linux-opensuse" class="page-distro">
+                            <h2>Install OpenRCT2 for openSUSE</h2>
+                            <ol class="steps">
+                                <li>
+                                    <div class="step"><span>1</span></div>
+                                    <div class="step-body">
+                                        <h3>Install OpenRCT2</h3>
+                                        <div>You can obtain the latest release or develop version of OpenRCT2 from the <a href="https://build.opensuse.org/package/show/games/openrct2">OBS</a>.</div>
+                                        <div class="terminal">sudo zypper install openrct2</div>
+                                    </div>
+                                </li>
+                                <li>
+                                    <div class="step"><span>2</span></div>
+                                    <div class="step-body">
+                                        <h3>Find your RCT2 installation</h3>
+                                        <p>When OpenRCT2 first launches, you will be prompted to select the directory where you installed RCT2. You can also set the RCT2 path from the command line should you wish - use the command below.</p>
+                                        <div class="terminal">openrct2 set-rct2 /path/to/rct2-install</div>
+                                    </div>
+                                </li>
+                            </ol>
+                        </div>
+                        <div id="content-linux-ubuntu" class="page-distro">
+                            <h2>Install OpenRCT2 for Debian 8, Ubuntu 16.04, 16.10 &amp;amp; Mint 18</h2>
+                            <ol class="steps">
+                                <li>
+                                    <div class="step"><span>1</span></div>
+                                    <div class="step-body">
+                                        <h3>Install OpenRCT2</h3>
+                                        <div>You can obtain the latest release or develop version of OpenRCT2 from this <a href="https://launchpad.net/~openrct2/+archive/ubuntu/master">PPA</a>.</div>
+                                        <div class="terminal">sudo add-apt-repository ppa:openrct2/master
+                                            sudo apt-get update
+                                            sudo apt-get install openrct2
+                                        </div>
+                                    </div>
+                                </li>
+                                <li>
+                                    <div class="step"><span>2</span></div>
+                                    <div class="step-body">
+                                        <h3>Find your RCT2 installation</h3>
+                                        <p>When OpenRCT2 first launches, you will be prompted to select the directory where you installed RCT2. You can also set the RCT2 path from the command line should you wish - use the command below.</p>
+                                        <div class="terminal">openrct2 set-rct2 /path/to/rct2-install</div>
+                                    </div>
+                                </li>
+                            </ol>
+                        </div>
+                    </div>
+                    <div id="content-macos" class="page-platform">
+                        <h2>Install OpenRCT2 for macOS</h2>
                         <ol class="steps">
                             <li>
                                 <div class="step"><span>1</span></div>
                                 <div class="step-body">
                                     <h3>Install OpenRCT2</h3>
-                                    <p>You can obtain the latest release or develop version of OpenRCT2 from <a href="https://openrct2.website">OpenRCT2</a>.</p>
-                                    <div><a class="btn-download" href="https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.0.7/OpenRCT2-0.0.7-windows-portable-x64.zip">Download latest release</a></div>
+                                    <p>Use the links below to download OpenRCT2. The latest release is a stable, well-tested build, but may have fewer features than the latest development builds. The dev builds are analogous to beta versions - they should work, but don't expect everything to be perfect.</p>
+                                        <p>Note: If you wish to play online, it is recommended to use the latest development build, as most servers will be running this; you cannot connect to a server running a different version.</p>
+                                    <div><a class="btn-download" href="http://cdn.limetric.com/games/openrct2/0.0.7/master/36f1210/3/OpenRCT2-0.0.7-macos.zip">Download latest release</a></div>
                                     <div><a class="btn-download" href="https://openrct2.org/downloads/latest/develop">Download latest development build</a></div>
                                 </div>
                             </li>
                             <li>
-                                <div class="step"><span>2</span></div>
-                                <div class="step-body">
-                                    <h3>Find your RCT2 installation</h3>
-                                    <p>When you launch OpenRCT2 for the first time, OpenRCT2 will try to find your RCT2 installation. It will check the default locations
-                                        that RCT2 is typically installed for all known releases. If it is unable to find it, or you have installed it to a different location,
-                                        OpenRCT2 will show a dialog allowing you to select the directory containing your RCT2 files.
-                                    </p>
-                                </div>
-                            </li>
-                        </ol>
-                    </div>
-                    <div id="content-windows-x64" class="page-distro show">
-                        <h2>Install OpenRCT2 for Windows (64 bit)</h2>
-                        <ol class="steps">
-                            <li>
-                                <div class="step"><span>1</span></div>
-                                <div class="step-body">
-                                    <h3>Install OpenRCT2</h3>
-                                    <p>You can obtain the latest release or develop version of OpenRCT2 from <a href="https://openrct2.website">OpenRCT2</a>.</p>
-                                    <div><a class="btn-download" href="https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.0.7/OpenRCT2-0.0.7-windows-portable-x64.zip">Download latest release</a></div>
-                                    <div><a class="btn-download" href="https://openrct2.org/downloads/latest/develop">Download latest development build</a></div>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="step"><span>2</span></div>
-                                <div class="step-body">
-                                    <h3>Find your RCT2 installation</h3>
-                                    <p>When you launch OpenRCT2 for the first time, OpenRCT2 will try to find your RCT2 installation. It will check the default locations
-                                        that RCT2 is typically installed for all known releases. If it is unable to find it, or you have installed it to a different location,
-                                        OpenRCT2 will show a dialog allowing you to select the directory containing your RCT2 files.
-                                    </p>
-                                </div>
-                            </li>
+                                    <div class="step"><span>2</span></div>
+                                    <div class="step-body">
+                                        <h3>Find your RCT2 installation</h3>
+                                        <p>When OpenRCT2 first launches, you will be prompted to select the directory where you installed RCT2. You can also set the RCT2 path from the command line should you wish - use the command below.</p>
+                                        <div class="terminal">openrct2 set-rct2 /path/to/rct2-install</div>
+                                    </div>
+                                </li>
                         </ol>
                     </div>
                 </div>
-                <div id="content-linux" class="page-platform">
-                    <div class="btn-h-container-center btn-distros">
-                        <div>Select your Linux distro</div>
-                        <div class="btn-h-container">
-                            <button class="btn-distro active" data-page="content-linux-arch">Arch Linux</button>
-                            <button class="btn-distro" data-page="content-linux-opensuse">openSUSE</button>
-                            <button class="btn-distro" data-page="content-linux-ubuntu">Debian, Ubuntu, Mint</button>
-                            <button class="btn-distro" data-page="content-linux-alpine">Alpine</button>
-                            <button class="btn-distro" data-page="content-linux-gentoo">Gentoo</button>
-                            <button class="btn-distro" data-page="content-linux-fedora">Fedora</button>
-                        </div>
-                    </div>
-                    <div id="content-linux-arch" class="page-distro show">
-                        <h2>Install OpenRCT2 for Arch Linux</h2>
-                        <ol class="steps">
-                            <li>
-                                <div class="step"><span>1</span></div>
-                                <div class="step-body">
-                                    <h3>Install OpenRCT2</h3>
-                                    <div>You can obtain the latest release or develop version of OpenRCT2 from the <a href="https://aur.archlinux.org">AUR</a>.</div>
-                                    <div class="terminal">yaourt -S openrct2</div>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="step"><span>2</span></div>
-                                <div class="step-body">
-                                    <h3>Find your RCT2 installation</h3>
-                                    <div class="terminal">openrct2 set-rct2 /path/to/rct2-install</div>
-                                </div>
-                            </li>
-                        </ol>
-                    </div>
-                    <div id="content-linux-alpine" class="page-distro show">
-                        <h2>Install OpenRCT2 for Alpine Linux</h2>
-                        <ol class="steps">
-                            <li>
-                                <div class="step"><span>1</span></div>
-                                <div class="step-body">
-                                    <h3>Install dependencies</h3>
-                                    <div>You will need the dependencies to build the game - there is no package in apk for the game as of yet.</div>
-                                    <div class="terminal">apk add git gcc g++ jansson-dev libzip-dev curl-dev libressl-dev sdl2-dev fontconfig-dev sdl2_ttf-dev fts-dev</div>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="step"><span>2</span></div>
-                                <div class="step-body">
-                                    <h3>Build the game</h3>
-                                    <div class="terminal">git clone https://github.com/OpenRCT2/OpenRCT2.git &amp;&amp; cd ./OpenRCT2 &amp;&amp; mkdir build &amp;&amp; cd build &amp;&amp; cmake ../ &amp;&amp; make</div>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="step"><span>3</span></div>
-                                <div class="step-body">
-                                    <h3>Set up the files</h3>
-                                    <div class="terminal">cp -r ../data/ ./data/ &amp;&amp; make g2 &amp;&amp; mv ./g2.dat ./data/g2.dat</div>
-                                </div>
-                            <li>
-                            <li>
-                                <div class="step"><span>4</span></div>
-                                <div class="step-body">
-                                    <h3>Find your RCT2 installation</h3>
-                                    <div class="terminal">openrct2 set-rct2 /path/to/rct2-install</div>
-                                </div>
-                            <li>
-                        </ol>
-                    </div>
-                    <div id="content-linux-gentoo" class="page-distro show">
-                        <h2>Install OpenRCT2 for Gentoo</h2>
-                        <ol class="steps">
-                            <li>
-                                <div class="step"><span>1</span></div>
-                                <div class="step-body">
-                                    <h3>Install dependencies</h3>
-                                    <div>You will need the dependencies to build the game - there is no package for the game as of yet.</div>
-                                    <div class="terminal">I don't know how gentoo package management works - Please fill this out - Krutonium</div>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="step"><span>2</span></div>
-                                <div class="step-body">
-                                    <h3>Build the game</h3>
-                                    <div class="terminal">git clone https://github.com/OpenRCT2/OpenRCT2.git &amp;&amp; cd ./OpenRCT2 &amp;&amp; mkdir build &amp;&amp; cd build &amp;&amp; cmake ../ &amp;&amp; make</div>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="step"><span>3</span></div>
-                                <div class="step-body">
-                                    <h3>Set up the files</h3>
-                                    <div class="terminal">cp -r ../data/ ./data/ &amp;&amp; make g2 &amp;&amp; mv ./g2.dat ./data/g2.dat</div>
-                                </div>
-                            <li>
-                            <li>
-                                <div class="step"><span>4</span></div>
-                                <div class="step-body">
-                                    <h3>Find your RCT2 installation</h3>
-                                    <div class="terminal">openrct2 set-rct2 /path/to/rct2-install</div>
-                                </div>
-                            <li>
-                        </ol>
-                    </div>
-                    <div id="content-linux-fedora" class="page-distro show">
-                        <h2>Install OpenRCT2 for Fedora</h2>
-                        <ol class="steps">
-                            <li>
-                                <div class="step"><span>1</span></div>
-                                <div class="step-body">
-                                    <h3>Install dependencies</h3>
-                                    <div>You will need the dependencies to build the game - there is no package for the game as of yet.</div>
-                                    <div class="terminal">sudo dnf install gcc gcc-c++ jansson-devel \
-                                        SDL2_ttf-devel openssl-devel \
-                                        speexdsp-devel libcurl-devel \
-                                        cmake fontconfig-devel freetype-devel \
-                                        libpng-devel libzip-devel mesa-libGL-devel
-                                    </div>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="step"><span>2</span></div>
-                                <div class="step-body">
-                                    <h3>Build the game</h3>
-                                    <div class="terminal">git clone https://github.com/OpenRCT2/OpenRCT2.git &amp;&amp; cd ./OpenRCT2 &amp;&amp; mkdir build &amp;&amp; cd build &amp;&amp; cmake ../ &amp;&amp; make</div>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="step"><span>3</span></div>
-                                <div class="step-body">
-                                    <h3>Set up the files</h3>
-                                    <div class="terminal">cp -r ../data/ ./data/ &amp;&amp; make g2 &amp;&amp; mv ./g2.dat ./data/g2.dat</div>
-                                </div>
-                            <li>
-                            <li>
-                                <div class="step"><span>4</span></div>
-                                <div class="step-body">
-                                    <h3>Find your RCT2 installation</h3>
-                                    <div class="terminal">openrct2 set-rct2 /path/to/rct2-install</div>
-                                </div>
-                            <li>
-                        </ol>
-                    </div>
-                    <div id="content-linux-opensuse" class="page-distro show">
-                        <h2>Install OpenRCT2 for openSUSE</h2>
-                        <ol class="steps">
-                            <li>
-                                <div class="step"><span>1</span></div>
-                                <div class="step-body">
-                                    <h3>Install OpenRCT2</h3>
-                                    <div>You can obtain the latest release or develop version of OpenRCT2 from the <a href="https://build.opensuse.org/package/show/games/openrct2">OBS</a>.</div>
-                                    <div class="terminal">sudo zypper install openrct2</div>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="step"><span>2</span></div>
-                                <div class="step-body">
-                                    <h3>Find your RCT2 installation</h3>
-                                    <div class="terminal">openrct2 set-rct2 /path/to/rct2-install</div>
-                                </div>
-                            </li>
-                        </ol>
-                    </div>
-                    <div id="content-linux-ubuntu" class="page-distro show">
-                        <h2>Install OpenRCT2 for Debian 8, Ubuntu 16.04, 16.10 &amp;amp; Mint 18</h2>
-                        <ol class="steps">
-                            <li>
-                                <div class="step"><span>1</span></div>
-                                <div class="step-body">
-                                    <h3>Install OpenRCT2</h3>
-                                    <div>You can obtain the latest release or develop version of OpenRCT2 from this <a href="https://launchpad.net/~openrct2/+archive/ubuntu/master">PPA</a>.</div>
-                                    <div class="terminal">sudo add-apt-repository ppa:openrct2/master
-                                        sudo apt-get update
-                                        sudo apt-get install openrct2
-                                    </div>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="step"><span>2</span></div>
-                                <div class="step-body">
-                                    <h3>Find your RCT2 installation</h3>
-                                    <div class="terminal">openrct2 set-rct2 /path/to/rct2-install</div>
-                                </div>
-                            </li>
-                        </ol>
-                    </div>
-                </div>
-                <div id="content-macos" class="page-platform">
-                    <h2>Install OpenRCT2 for macOS</h2>
-                    <ol class="steps">
-                        <li>
-                            <div class="step"><span>1</span></div>
-                            <div class="step-body">
-                                <h3>Install OpenRCT2</h3>
-                                <p>You can obtain the latest release or develop version of OpenRCT2 from <a href="https://openrct2.website">OpenRCT2</a>.</p>
-                                <div><a class="btn-download" href="https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.0.7/OpenRCT2-0.0.7-macos.zip">Download latest release</a></div>
-                                <div><a class="btn-download" href="https://openrct2.org/downloads/latest/develop">Download latest development build</a></div>
-                            </div>
-                        </li>
-                        <li>
-                            <div class="step"><span>2</span></div>
-                            <div class="step-body">
-                                <h3>Find your RCT2 installation</h3>
-                                You can obtain the latest release or develop version of OpenRCT2 from <a href="https://openrct2.website">OpenRCT2</a>.
-                            </div>
-                        </li>
-                    </ol>
+                <div id="content-phase-four" class="page-phase">
+                <h2>Tips &amp; tricks</h2>
+                    <h3>Importing RCT1 data</h3>
+                        <p>OpenRCT2 can pick up RCT1 scenarios, title sequences and image data (giving improved appearance to some roller coaster types). To do this, follow the steps below.</p>
+                        <p>Firstly, install or extract RCT1 (follow the instructions in step 2, substituting the RCT1 installer for the RCT2 one).</p>
+                        <p>Launch OpenRCT2 and go to the <strong>Options</strong> menu (top right on the title screen).</p>
+                        <p>Go to the sixth tab (the spanner), and click the box under <strong>Path to RCT1 installation</strong>.</p>
+                        <img src="https://camo.githubusercontent.com/a3fed282f826eaa4eb6f155bc55035dce7970263/687474703a2f2f692e696d6775722e636f6d2f544663597644762e706e67" />
+                        <p>A folder selection dialog will pop up - navigate to the folder where your RCT1 files are and click 'Open'.</p>
+                    <h3>Multiplayer</h3>
+                        <p>You can play OpenRCT2 online in collaboration with others! To do so, click the third option on the main menu, which will bring up the server browser.</p>
+                        <img src="http://i.imgur.com/mOQZ1UX.png" />
+                        <p>The server browser allows you to set your player name (by default your computer account username), select a server to play on or create your own server.</p>
+                        <img src="http://i.imgur.com/lDvkejX.png" />
+                        <p>Note the red and green circles on the right hand side, and the text in the bottom right referring to the <strong>network version</strong>.</p>
+                        <p>You can only connect to servers that are on the same network version as you. Hovering over the circles will tell you what version the server is running. If it is higher than yours, update your copy of OpenRCT2. If it is lower than yours, you'll need to contact the server admins and ask them to update.</p>
+                        <p>A full technical guide to multiplayer which includes instructions on setting up a server is available <a href="https://github.com/OpenRCT2/OpenRCT2/wiki/Multiplayer">here on the OpenRCT2 wiki</a>.</p>
                 </div>
             </div>
         </div>
-        <script type="text/javascript">
-            function setupPageControl(container, pageType) {
-                var buttons = document.querySelectorAll(container + ' .btn-' + pageType);
-                for (var i = 0; i < buttons.length; i++) {
-                    buttons[i].addEventListener('click', function () {
-                        if (!this.classList.contains('active')) {
-                            var activeButtons = document.querySelectorAll(container + ' .btn-' + pageType + '.active');
-                            for (var j = 0; j < activeButtons.length; j++) {
-                                activeButtons[j].classList.remove('active');
-                            }
-                            this.classList.add('active');
-            
-                            var pages = document.querySelectorAll(container + ' .page-' + pageType);
-                            for (var j = 0; j < pages.length; j++) {
-                                pages[j].classList.remove('show');
-                            }
-                            var targetPage = document.getElementById(this.getAttribute('data-page'));
-                            if (targetPage) {
-                                targetPage.classList.add('show');
-                            }
-                        }
-                    });
-                }
-            }
-            
-            setupPageControl('body', 'platform');
-            
-            var platformPages = document.querySelectorAll('.page-platform');
-            for (var i = 0; i < platformPages.length; i++) {
-                var container = '#' + platformPages[i].id;
-                setupPageControl(container, 'distro');
-            }
-        </script>
+        <script type="text/javascript" src="../assets/js/openrct2.website.js"></script>
+        <script type="text/javascript" src="../assets/js/getting-started.js"></script>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5,98 +5,16 @@
   <meta name="viewport" content="width=device-width, user-scalable=no">
   <title>OpenRCT2</title>
   <link rel="stylesheet" href="assets/css/index.css">
-  <script type="text/javascript">
-    // http://stackoverflow.com/questions/15900485/correct-way-to-convert-size-in-bytes-to-kb-mb-gb-in-javascript
-    function formatBytes (bytes, decimals) {
-       if(bytes == 0) return '0 Byte';
-       var k = 1000;
-       var dm = decimals + 1 || 3;
-       var sizes = ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
-       var i = Math.floor(Math.log(bytes) / Math.log(k));
-       return (bytes / Math.pow(k, i)).toPrecision(dm) + ' ' + sizes[i];
-    }
-
-    var platforms = {
-      windows: {
-        name: 'Windows',
-        link: 'https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.0.6/OpenRCT2-0.0.6.0-windows-portable-x64.zip',
-        size: 6462629, //bytes
-        version: '0.0.6'
-      },
-      linux: {
-        name: 'Linux',
-        link: 'https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.0.6/OpenRCT2-0.0.6.0-linux-x86_64.tar.gz',
-        size: 14009751, //bytes
-        version: '0.0.6'
-      },
-      osx: {
-        name: 'OS X',
-        link: 'https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.0.6/OpenRCT2-0.0.6.0-macos.zip',
-        size: 7266860,
-        version: '0.0.6'
-      }
-    }
-
-    var current;
-
-    document.addEventListener('DOMContentLoaded', function () {
-      var link = document.getElementsByClassName('link')[0];
-      var size = document.getElementsByClassName('size')[0];
-      var version = document.getElementsByClassName('version')[0];
-      var platform = document.getElementsByClassName('platform')[0];
-
-      if (navigator.platform.indexOf('Win') >= 0){
-        current = platforms.windows;
-      }
-
-      if (navigator.platform.indexOf('Linux') >= 0){
-        current = platforms.linux;
-      }
-
-      if (navigator.platform === 'MacIntel'){
-        current = platforms.osx;
-      }
-
-      if (current) {
-        link.href = current.link;
-        size.innerHTML = formatBytes(current.size, 1);
-        platform.innerHTML = current.name;
-        version.innerHTML = current.version;
-      }
-
-      platform.addEventListener('click', function (e) {
-        e.preventDefault();
-        
-        var keys = Object.keys(platforms);
-
-        for (var i = 0; i <= keys.length; i++) {
-          if (platforms[keys[i]].name === platform.innerHTML) {
-            if (i + 1 >= keys.length) {
-              i = 0;
-            } else {
-              i = i + 1;
-            }
-            
-            link.href = platforms[keys[i]].link;
-            size.innerHTML = formatBytes(platforms[keys[i]].size, 1);
-            platform.innerHTML = platforms[keys[i]].name;
-            version.innerHTML = platforms[keys[i]].version;
-            break;
-          }
-        }
-      });
-    });
-  </script>
 </head>
 <body>
-  <a href="https://github.com/OpenRCT2/OpenRCT2"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/52760788cde945287fbb584134c4cbc2bc36f904/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f77686974655f6666666666662e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png"></a>
-  <div id="background">
+    <a href="https://github.com/OpenRCT2/OpenRCT2"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/52760788cde945287fbb584134c4cbc2bc36f904/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f77686974655f6666666666662e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png"></a>
+    <div id="background">
     <video autoplay loop poster="assets/img/poster.jpg">
       <source src="assets/video.mp4" type="video/mp4">
     </video>
-  </div>
-  <div id="gradient"></div>
-  <div id="content">
+    </div>
+    <div id="gradient"></div>
+    <div id="content">
     <div id="logo">OpenRCT2</div>
     <h1>OpenRCT2</h1>
     <h2>Open source re-implementation of RollerCoaster Tycoon 2</h2>
@@ -104,22 +22,29 @@
       <li>
         <a class="link" href="https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.0.6/OpenRCT2-v0.0.6.0-windows-portable-x64.zip">Download Latest Release</a>
         <div class="information">
-          <span class="version">0.0.6</span> — <a class="platform" href="#" title="Change platform…">Windows</a> — <span class="size">5.9 MB</span>
+          <span class="version">0.0.6</span> — <a class="platform" href="#" title="Change platform…">Windows (64-bit)</a> — <span class="size">5.9 MB</span>
         </div>
       </li>
       <li>
         <a href="https://openrct2.org/downloads/latest/develop">Download Development Build</a>
         <div class="information">Windows, Linux &amp; OS X</div>
       </li>
+      <li>
+        <a href="getting-started/index.html">Getting Started Guide</a>
+        <div class="information">Installation, setup &amp; hints</div>
+      </li>
     </ul>
-  </div>
-  <div id="footer">
+    </div>
+    <div id="footer">
     <ul>
       <li><a href="https://github.com/OpenRCT2/OpenRCT2/wiki">Wiki</a></li>
       <li><a href="https://openrct2.org/forums/">Forums</a></li>
       <li><a href="https://raw.githubusercontent.com/OpenRCT2/OpenRCT2/develop/distribution/changelog.txt">Changelog</a></li>
       <li><a href="https://servers.openrct2.website/">Master Server</a></li>
     </ul>
-  </div>
+    </div>
+
+<script type="text/javascript" src="assets/js/openrct2.website.js"></script>
+<script type="text/javascript" src="assets/js/home.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This PR fleshes out the Getting Started page and adds a link to it from the homepage, and refactors the JS in order to make showing/hiding content based on platform easier.

The Getting Started page should automatically display the relevant content for the user's platform (assuming their browser reports things sensibly). Of course, the user can simply click the relevant button to see the other sections.

See it in action [here](http://serenity.uk.net/openrct2/index.html).