### PR TITLE
Update getting started downloads to 0.1.1

### DIFF
--- a/getting-started/index.html
+++ b/getting-started/index.html
@@ -94,7 +94,7 @@
                                         <h3>Install OpenRCT2</h3>
                                         <p>Use the links below to download OpenRCT2. The latest release is a stable, well-tested build, but may have fewer features than the latest development builds. The dev builds are analogous to beta versions - they should work, but don't expect everything to be perfect.</p>
                                         <p>Note: If you wish to play online, it is recommended to use the latest development build, as most servers will be running this; you cannot connect to a server running a different version.</p>
-                                        <div><a class="btn-download" href="https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.1.0/OpenRCT2-0.1.0-windows-installer-win32.exe">Download latest release</a></div>
+                                        <div><a class="btn-download" href="https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.1.1/OpenRCT2-0.1.1-windows-installer-win32.exe">Download latest release</a></div>
                                         <div><a class="btn-download" href="https://openrct2.org/downloads/latest/develop">Download latest development build</a></div>
                                     </div>
                                 </li>
@@ -119,7 +119,7 @@
                                         <h3>Install OpenRCT2</h3>
                                         <p>Use the links below to download OpenRCT2. The latest release is a stable, well-tested build, but may have fewer features than the latest development builds. The dev builds are analogous to beta versions - they should work, but don't expect everything to be perfect.</p>
                                         <p>Note: If you wish to play online, it is recommended to use the latest development build, as most servers will be running this; you cannot connect to a server running a different version.</p>
-                                        <div><a class="btn-download" href="https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.1.0/OpenRCT2-0.1.0-windows-installer-x64.exe">Download latest release</a></div>
+                                        <div><a class="btn-download" href="https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.1.1/OpenRCT2-0.1.1-windows-installer-x64.exe">Download latest release</a></div>
                                         <div><a class="btn-download" href="https://openrct2.org/downloads/latest/develop">Download latest development build</a></div>
                                     </div>
                                 </li>
@@ -290,7 +290,7 @@
                                     <h3>Install OpenRCT2</h3>
                                     <p>Use the links below to download OpenRCT2. The latest release is a stable, well-tested build, but may have fewer features than the latest development builds. The dev builds are analogous to beta versions - they should work, but don't expect everything to be perfect.</p>
                                         <p>Note: If you wish to play online, it is recommended to use the latest development build, as most servers will be running this; you cannot connect to a server running a different version.</p>
-                                    <div><a class="btn-download" href="https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.1.0/OpenRCT2-0.1.0-macos.zip">Download latest release</a></div>
+                                    <div><a class="btn-download" href="https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.1.1/OpenRCT2-0.1.1-macos.zip">Download latest release</a></div>
                                     <div><a class="btn-download" href="https://openrct2.org/downloads/latest/develop">Download latest development build</a></div>
                                 </div>
                             </li>


### PR DESCRIPTION
The download links on https://openrct2.website/getting-started/ still linked to version 0.1.0, I updated them so they link to 0.1.1.