### PR TITLE
Change CNAME to openrct2.io

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-openrct2.website
+openrct2.io


### PR DESCRIPTION
Once this is done, we should set `openrct2.website` to redirect (HTTP 301) to `openrct2.io`.