### PR TITLE
Do not recommend AUR helpers

### DIFF
--- a/getting-started/index.html
+++ b/getting-started/index.html
@@ -156,9 +156,13 @@
                                     <div class="step-body">
                                         <h3>Install OpenRCT2</h3>
                                         <div>If you want the release build - stable, well-tested, but might have fewer features than the latest development build, install the standard package:</div>
-                                        <div class="terminal">yaourt -S openrct2</div>
+                                        <div class="terminal">git clone https://aur.archlinux.org/openrct2.git
+                                        cd openrct2
+                                        makepkg -si</div>
 										<div>Alternatively, if you want the latest development build, install the -git package from the <a href="https://aur.archlinux.org">AUR</a>. The dev builds are analogous to beta versions - they should work, but don't expect everything to be perfect.</div>
-                                        <div class="terminal">yaourt -S openrct2-git</div>
+                                        <div class="terminal">git clone https://aur.archlinux.org/openrct2-git.git
+                                        cd openrct2-git
+                                        makepkg -si</div>
                                     </div>
                                 </li>
                                 <li>


### PR DESCRIPTION
Yaourt is [bad](https://wiki.archlinux.org/index.php/AUR_helpers#Pacman_wrappers), and you should in general not recommend AUR helpers because the user should [know what they are doing](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages) if they want to install from the AUR.

Obviously, if a user just copies the commands, they still don't know what they are doing, but they are at least doing it themselves and not relying on a 3rd party program that does god knows what.