### PR TITLE
Update for 0.2.4 release

### DIFF
--- a/assets/js/openrct2.website.js
+++ b/assets/js/openrct2.website.js
@@ -4,27 +4,27 @@ openrct2.Platform = Object.freeze({
     UNKNOWN: {},
     WINDOWS32: {
         name: 'Windows (32-bit)',
-        link: 'https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.2.3/OpenRCT2-0.2.3-windows-portable-win32.zip',
-        size: 10292192,
-        version: '0.2.3'
+        link: 'https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.2.4/OpenRCT2-0.2.4-windows-portable-win32.zip',
+        size: 10001208,
+        version: '0.2.4'
     },
     WINDOWS64: {
         name: 'Windows (64-bit)',
-        link: 'https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.2.3/OpenRCT2-0.2.3-windows-portable-x64.zip',
-        size: 11027954,
-        version: '0.2.3'
+        link: 'https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.2.4/OpenRCT2-0.2.4-windows-portable-x64.zip',
+        size: 10763580,
+        version: '0.2.4'
     },
     MACOS: {
         name: 'macOS',
-        link: 'https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.2.3/OpenRCT2-0.2.3-macos-x64.zip',
-        size: 28150803,
-        version: '0.2.3'
+        link: 'https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.2.4/OpenRCT2-0.2.4-macos-x86_64.zip',
+        size: 23787783,
+        version: '0.2.4'
     },
     LINUX: {
         name: 'Linux',
-        link: 'https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.2.2/OpenRCT2-0.2.2-linux-x86_64.tar.gz',
-        size: 32162474,
-        version: '0.2.2'
+        link: 'https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.2.4/OpenRCT2-0.2.4-linux-x86_64.tar.gz',
+        size: 31592123,
+        version: '0.2.4'
     }
 });  // Object.freeze() prevents this from being futzed with
 

--- a/getting-started/index.html
+++ b/getting-started/index.html
@@ -94,7 +94,7 @@
                                         <h3>Install OpenRCT2</h3>
                                         <p>Use the links below to download OpenRCT2. The latest release is a stable, well-tested build, but may have fewer features than the latest development builds. The dev builds are analogous to beta versions - they should work, but don't expect everything to be perfect.</p>
                                         <p>Note: If you wish to play online, it is recommended to use the latest development build, as most servers will be running this; you cannot connect to a server running a different version.</p>
-                                        <div><a class="btn-download" href="https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.2.3/OpenRCT2-0.2.3-windows-installer-win32.exe">Download latest release</a></div>
+                                        <div><a class="btn-download" href="https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.2.4/OpenRCT2-0.2.4-windows-installer-win32.exe">Download latest release</a></div>
                                         <div><a class="btn-download" href="https://openrct2.org/downloads/latest/develop">Download latest development build</a></div>
                                     </div>
                                 </li>
@@ -119,7 +119,7 @@
                                         <h3>Install OpenRCT2</h3>
                                         <p>Use the links below to download OpenRCT2. The latest release is a stable, well-tested build, but may have fewer features than the latest development builds. The dev builds are analogous to beta versions - they should work, but don't expect everything to be perfect.</p>
                                         <p>Note: If you wish to play online, it is recommended to use the latest development build, as most servers will be running this; you cannot connect to a server running a different version.</p>
-                                        <div><a class="btn-download" href="https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.2.3/OpenRCT2-0.2.3-windows-installer-x64.exe">Download latest release</a></div>
+                                        <div><a class="btn-download" href="https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.2.4/OpenRCT2-0.2.4-windows-installer-x64.exe">Download latest release</a></div>
                                         <div><a class="btn-download" href="https://openrct2.org/downloads/latest/develop">Download latest development build</a></div>
                                     </div>
                                 </li>
@@ -319,7 +319,7 @@
                                     <h3>Install OpenRCT2</h3>
                                     <p>Use the links below to download OpenRCT2. The latest release is a stable, well-tested build, but may have fewer features than the latest development builds. The dev builds are analogous to beta versions - they should work, but don't expect everything to be perfect.</p>
                                         <p>Note: If you wish to play online, it is recommended to use the latest development build, as most servers will be running this; you cannot connect to a server running a different version.</p>
-                                    <div><a class="btn-download" href="https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.2.3/OpenRCT2-0.2.3-macos-x64.zip">Download latest release</a></div>
+                                    <div><a class="btn-download" href="https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.2.4/OpenRCT2-0.2.4-macos-x86_64.zip">Download latest release</a></div>
                                     <div><a class="btn-download" href="https://openrct2.org/downloads/latest/develop">Download latest development build</a></div>
                                 </div>
                             </li>

--- a/index.html
+++ b/index.html
@@ -20,9 +20,9 @@
     <h2>Open source re-implementation of RollerCoaster Tycoon 2</h2>
     <ul id="buttons">
       <li>
-        <a class="link" href="https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.2.3/OpenRCT2-0.2.3-windows-portable-x64.zip">Download Latest Release</a>
+        <a class="link" href="https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.2.4/OpenRCT2-0.2.4-windows-portable-x64.zip">Download Latest Release</a>
         <div class="information">
-          <span class="version">0.2.3</span> — <a class="platform" href="#" title="Change platform…">Windows (64-bit)</a> — <span class="size">11 MiB</span>
+          <span class="version">0.2.4</span> — <a class="platform" href="#" title="Change platform…">Windows (64-bit)</a> — <span class="size">11 MiB</span>
         </div>
       </li>
       <li>


### PR DESCRIPTION
Carefully updated, but not sure how to test it.

Three things that I'm not 100% sure about:
 - `...-macos-x64` is now named `...-macos-x86_64`?
 - Linux was never updated to 0.2.3 for a reason?
 - There is no download for Linux builds on the website (at least not in index.html)?