### PR TITLE
Update installation instructions for Steam version on Linux

### DIFF
--- a/getting-started/index.html
+++ b/getting-started/index.html
@@ -44,7 +44,7 @@
                         <h4>GOG.com & Retail</h4>
                         <p>You can use WINE - a reimplementation of the Windows API - to run the installer. Using a wrapper such as <a href="https://www.playonlinux.com">PlayOnLinux</a> or <a href="https://www.playonmac.com">PlayOnMac</a> is recommended to make the process easier. Follow the wizard the wrapper provides, pointing it to the installer at the appropriate point. It does not matter if RCT2 actually runs, as we'll be using the OpenRCT2 application.</p>
                         <h4>Steam</h4>
-                        Follow a guide for installing Steam via WINE, such as <a href="https://wiki.archlinux.org/index.php/Steam/Wine">this excellent one</a> from the Arch Wiki. Download and install RCT2, remembering to note/copy the path where you installed it.
+                        <p>You'll need to tick "Enable Steam Play for all other titles" in the "Steam Play" tab of Steam's settings. Steam will ask to restart, and then it will allow you to install RCT2 as any other Steam game. Once you've done so, click the gear icon on the game's page in your library, then select "Manage"->"Browse local files" to open the directory where the game was installed.</p>
                         <h3>Option 2: Manual extraction</h3>
                         <h4>GOG.com</h4>
                         <p>If you have the GOG.com installer, you can extract it using <a href="http://constexpr.org/innoextract/">innoextract</a>. Check if your distribution has a package for it, if not it can be downloaded from the link provided.</p>


### PR DESCRIPTION
Proton has made installing Steam in Wine unnecessary for a long time now. The previously-linked Arch Wiki guide doesn't even exist anymore; it's been archived.