### PR TITLE
Update getting started install steps for Arch

### DIFF
--- a/getting-started/index.html
+++ b/getting-started/index.html
@@ -157,7 +157,7 @@
                                     <div class="step"><span>1</span></div>
                                     <div class="step-body">
                                         <h3>Install OpenRCT2</h3>
-                                        <div>If you want the release build - stable, well-tested, but might have fewer features than the latest development build, install the standard <a href="https://archlinux.org/packages/community/x86_64/openrct2/">openrct2</a> package:</div>
+                                        <div>If you want the release build (some servers use these), install the standard <a href="https://archlinux.org/packages/community/x86_64/openrct2/">openrct2</a> package:</div>
                                         <div class="terminal">sudo pacman -S openrct2</div>
 										<div>Alternatively, if you want the latest development build, install the -git package from the <a href="https://aur.archlinux.org">AUR</a>. The dev builds are analogous to beta versions - they should work, but don't expect everything to be perfect.</div>
                                         <div class="terminal">git clone https://aur.archlinux.org/openrct2-git.git

--- a/getting-started/index.html
+++ b/getting-started/index.html
@@ -157,10 +157,8 @@
                                     <div class="step"><span>1</span></div>
                                     <div class="step-body">
                                         <h3>Install OpenRCT2</h3>
-                                        <div>If you want the release build - stable, well-tested, but might have fewer features than the latest development build, install the standard package:</div>
-                                        <div class="terminal">git clone https://aur.archlinux.org/openrct2.git
-                                        cd openrct2
-                                        makepkg -si</div>
+                                        <div>If you want the release build - stable, well-tested, but might have fewer features than the latest development build, install the standard <a href="https://archlinux.org/packages/community/x86_64/openrct2/">openrct2</a> package:</div>
+                                        <div class="terminal">sudo pacman -S openrct2</div>
 										<div>Alternatively, if you want the latest development build, install the -git package from the <a href="https://aur.archlinux.org">AUR</a>. The dev builds are analogous to beta versions - they should work, but don't expect everything to be perfect.</div>
                                         <div class="terminal">git clone https://aur.archlinux.org/openrct2-git.git
                                         cd openrct2-git


### PR DESCRIPTION
Package openrct2 was [deleted](https://lists.archlinux.org/pipermail/aur-requests/2020-October/045845.html) from AUR because it is available in Community repository. AUR link is no longer available.

I am not sure how to update the same guide on [openrct2.org](https://openrct2.org/quickstart/install/linux/arch-linux). Should I drop an email to mail@openrct2.org?

readme.md update: https://github.com/OpenRCT2/OpenRCT2/pull/14575